### PR TITLE
Skipping empty values

### DIFF
--- a/src/AbstractDocument.php
+++ b/src/AbstractDocument.php
@@ -551,7 +551,8 @@ abstract class AbstractDocument
      */
     public function setValue( $expr, $value, $context = null )
     {
-        $this->getElement($expr, $context)->nodeValue = $value;
+        if (!is_null($value))
+            $this->getElement($expr, $context)->nodeValue = $value;
 
         return $this;
     }


### PR DESCRIPTION
This is intended to simplify set of multiple values, such as in:

```
$e->setValues('DatiTrasmissione', [
    // ...
    'PECDestinatario' => $customer->sdi_code == '0000000' ? $customer->pec : null,
    // ...
]);
```